### PR TITLE
feat: add descriptive paragraph to Beethoven page for enhanced context

### DIFF
--- a/src/app/(web)/beethoven/page.tsx
+++ b/src/app/(web)/beethoven/page.tsx
@@ -11,6 +11,7 @@ export default async function Page(props: {
   return (
     <div className="flex flex-col items-center justify-center h-screen">
       <h1 className="text-3xl font-bold py-4">The BSO and Beethoven Symphonies</h1>
+      <p className="text-lg text-gray-500 pb-4 max-w-4xl">This chart shows the number of times each Beethoven symphony has been performed by the Boston Symphony Orchestra, grouped by the starting year of the season.</p>
       <div>
         <Suspense fallback={<div>Loading...</div>}>
           <ConductorComponent />


### PR DESCRIPTION
- Included a new paragraph explaining the chart's purpose, detailing the performance frequency of Beethoven's symphonies by the Boston Symphony Orchestra, grouped by season start year.